### PR TITLE
Fix installation with `dolfinx` main

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,5 +15,8 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install --break-system-packages pyvista pytest
 
+      - name: Install python package
+        run: python3 -m pip install --check-build-dependencies .
+ 
       - name: Run unit tests
         run: python3 -m pytest test/

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if sys.version_info < (3, 10):
 
 VERSION = "0.9.0"
 
-REQUIREMENTS = ["pyvista", "fenics-dolfinx>0.9.0"]
+REQUIREMENTS = ["pyvista", "fenics-dolfinx>=0.9.0.dev0"]
 
 
 class CMakeExtension(Extension):


### PR DESCRIPTION
Allow for installation of `febug` with main branch of `dolfinx`. The previous check for `dolfinx` version being `>0.9.0` can not be satisfied, as `dolfinx` has no such version at the moment. 

This was not caught by the CI as the package was not installed with `pip` and passing `--check-build-dependencies` - this has been adapted. 